### PR TITLE
Fix: Preserve datetime64[ns] dtype in get_les_input output dataset

### DIFF
--- a/src/ls2d/ecmwf/read_era5.py
+++ b/src/ls2d/ecmwf/read_era5.py
@@ -741,7 +741,7 @@ class Read_era5:
 
         ds = xr.Dataset(
             coords={
-                'time': self.datetime,
+                'time': np.array(self.datetime).astype(self.time.dtype),
                 'z': z,
                 'zs': self.z_soil,
                 'lev': np.arange(self.nhalf),

--- a/src/ls2d/ecmwf/read_era5.py
+++ b/src/ls2d/ecmwf/read_era5.py
@@ -741,7 +741,7 @@ class Read_era5:
 
         ds = xr.Dataset(
             coords={
-                'time': np.array(self.datetime).astype(self.time.dtype),
+                'time': np.array(self.datetime, dtype='datetime64[ns]'),
                 'z': z,
                 'zs': self.z_soil,
                 'lev': np.arange(self.nhalf),


### PR DESCRIPTION
## Problem

When calling `get_les_input`, the `time` coordinate in the returned `xr.Dataset`
has dtype `datetime64[us]` (microsecond precision), even though the time coordinate
in the original ERA5 data uses `datetime64[ns]` (nanosecond precision). This
inconsistency causes dtype mismatches when the output dataset is compared against, interpolated to or
merged with data with dtype `datetime64[ns]`.

The root cause is in `get_les_input`, where the `time` coordinate is constructed
from `self.datetime` which is a plain Python `list` of `datetime.datetime` objects:

```python
ds = xr.Dataset(
    coords={
        'time': self.datetime,  # list of Python datetime objects
        ...
    }
)
```

In newer versions of xarray (≥ 2023), plain Python datetimes are inferred as
`datetime64[us]` rather than `datetime64[ns]`, changing the dtype of the output
silently.

## Fix

Explicitly cast the original dtype to the `time` coordinate:

```python
ds = xr.Dataset(
    coords={
       'time': np.array(self.datetime, dtype='datetime64[ns]'),
        ...
    }
)
```