### PR TITLE
Fix KeyError on `number` coordinate when saving patched NetCDF files

### DIFF
--- a/src/ls2d/ecmwf/patch_cds_ads.py
+++ b/src/ls2d/ecmwf/patch_cds_ads.py
@@ -59,8 +59,9 @@ def patch_netcdf(nc_file_path):
 
     # Drop `expver`; we need to save this file in classic NetCDF4 format, which
     # does not support variable length strings.
-    if 'expver' in ds.variables:
-        ds = ds.drop_vars('expver')
+    for coord in ("expver", "number"):
+        if coord in ds.variables or coord in ds.coords:
+            ds = ds.drop_vars(coord)
 
     file_name = os.path.basename(nc_file_path)
 


### PR DESCRIPTION
## Problem
ERA5 files (more specifically, the data on single levels and pressure levels) downloaded from the new CDS may contain a `number` coordinate representing the ensemble member ID . After `patch_netcdf` squeezes size-1 dimensions, this coordinate becomes a scalar with no corresponding dimension in the underlying file. When `regrid_netcdf` subsequently tries to save the dataset in `NETCDF4_CLASSIC` format, xarray attempts to encode `number`, causing a `KeyError`.

```
KeyError: 'number'
Raised while encoding variable 'number' with value <xarray.Variable ()> Size: 4B
[1 values with dtype=int32]
Attributes:
    long_name:      ensemble member numerical id
    units:          1
    standard_name:  realization
```

## Fix
Drop `number` (similar to  `expver`) early in `patch_netcdf` after opening the dataset.

```python
for coord in ('expver', 'number'):
    if coord in ds.variables or coord in ds.coords:
        ds = ds.drop_vars(coord)
```

## Notes
- `number` is not used anywhere downstream in LS2D
- Fixes the pipeline for ERA5 ensemble data downloaded via the new CDS