### PR TITLE
L137_grid.txt and L60_grid.txt not automatically installed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,7 +161,7 @@ cython_debug/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+.idea/
 
 ### Python Patch ###
 # Poetry local configuration file - https://python-poetry.org/docs/configuration/#local-configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,13 +3,11 @@ requires = ["setuptools>=61.0.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
+include-package-data = true
 package-dir = {"" = "src"}
 
 [tool.setuptools.packages.find]
 where = ["src"]
-
-[tool.setuptools.package-data]
-"ecmwf" = ["*.txt"]
 
 [project]
 name = "ls2d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ package-dir = {"" = "src"}
 where = ["src"]
 
 [tool.setuptools.package-data]
-ecmwf = ["*.txt"]
+ls2d = ["ecmwf/*.txt"]
 
 [project]
 name = "ls2d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,9 @@ package-dir = {"" = "src"}
 [tool.setuptools.packages.find]
 where = ["src"]
 
+[tool.setuptools.package-data]
+"ecmwf" = ["*.txt"]
+
 [project]
 name = "ls2d"
 version = "1.0.15"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,11 +3,13 @@ requires = ["setuptools>=61.0.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
-include-package-data = true
 package-dir = {"" = "src"}
 
 [tool.setuptools.packages.find]
 where = ["src"]
+
+[tool.setuptools.package-data]
+ecmwf = ["*.txt"]
 
 [project]
 name = "ls2d"


### PR DESCRIPTION
Despite the presence of these files in MANIFEST.in, they did not appear to be installed when using `uv` as package manager. Therefore, I added a section to pyproject.toml:
```toml
[tool.setuptools.package-data]
ls2d = ["ecmwf/*.txt"]
```